### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage and fix url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 
 license = "MIT"
 
-homepage = "https://github.con/fooker/netns-proxy"
+repository = "https://github.com/fooker/netns-proxy"
 readme = "./README.md"
 
 keywords = [


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/88